### PR TITLE
Save a few PublicSuffix parse calls, whenever possible

### DIFF
--- a/lib/naughty_or_nice.rb
+++ b/lib/naughty_or_nice.rb
@@ -48,8 +48,13 @@ class NaughtyOrNice
         $
       }xi
 
-  def initialize(text)
-    @text = text.to_s.downcase.strip
+  def initialize(domain)
+    if domain.is_a?(PublicSuffix::Domain)
+      @domain_parts = domain
+      @text = domain.to_s
+    else
+      @text = domain.to_s.downcase.strip
+    end
   end
 
   # Parse the domain from the input string
@@ -83,7 +88,7 @@ class NaughtyOrNice
   #
   # Returns boolean true if a valid domain, otherwise false
   def valid?
-    PublicSuffix.valid?(domain)
+    !!(domain_parts && domain_parts.valid?)
   end
 
   # Is the input text in the form of a valid email address?
@@ -99,9 +104,11 @@ class NaughtyOrNice
   #
   # Returns the domain object or nil, but no errors, never an error
   def domain_parts
-    PublicSuffix.parse domain
-  rescue PublicSuffix::DomainInvalid
-    nil
+    @domain_parts ||= begin
+      PublicSuffix.parse domain
+    rescue PublicSuffix::DomainInvalid, PublicSuffix::DomainNotAllowed
+      nil
+    end
   end
 
   def inspect

--- a/test/test_naughty_or_nice.rb
+++ b/test/test_naughty_or_nice.rb
@@ -11,6 +11,11 @@ class TestNaughtyOrNice < Minitest::Test
     assert_equal nil, NaughtyOrNice.new("foo").domain
   end
 
+  should "accept PublicSuffix::Domains" do
+    domain = PublicSuffix.parse("foo.gov")
+    assert_equal "foo.gov", NaughtyOrNice.new(domain).domain
+  end
+
   should "not err out on invalid domains" do
     assert_equal false, NaughtyOrNice.valid?("foo@gov.invalid")
     assert_equal "gov.invalid", NaughtyOrNice.new("foo@gov.invalid").domain


### PR DESCRIPTION
1. Allow initialize to accept an already-parsed public suffix domain
2. Have valid look to `domain_parts`, to potentially save a call
3. Memoize `domain_parts`