### PR TITLE
Make Naughty or Nice a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,16 @@ Naughty or Nice simplifies the process of extracting domain information from a d
 
 Naughty or Nice doesn't do too much on its own. Out of the box, it can extract a domain from a domain-like string, and can verify that it is, in fact, a valid domain. It does this by leveraging the power of [Addressable](https://github.com/sporkmonger/addressable), the [Public Suffix List](http://publicsuffix.org/), and the associated [Ruby Gem](https://github.com/weppos/publicsuffix-ruby).
 
-The true power of Naughty or Nice comes when you extended it into a child class.
+The true power of Naughty or Nice comes when you include it into your own class.
 
-## Extending Naughty or Nice
+## Implementing Naughty or Nice
 
 Let's say you have a list of three domains, `foo.com`, `bar.com`, and `foobar.com`. You'd spec out a class like so:
 
 ```ruby
-class Checker < NaughtyOrNice
+class Checker
+
+  include NaughtyOrNice
   DOMAINS = %w[foo.com bar.com foobar.com]
 
   def valid?
@@ -26,9 +28,9 @@ end
 
 That's it! Just overwrite the `valid?` method and Naughty or Nice takes care of the rest.
 
-## Using the extended class
+## Using the included methods
 
-There are a handful of magic methods that your child class automatically gets. You can throw any domain-like string at your new `Checker` class, and figure out if it's on the list. Here's a few examples:
+There are a handful of magic methods that your class automatically gets. You can throw any domain-like string at your new `Checker` class, and figure out if it's on the list. Here's a few examples:
 
 ```ruby
 Checker.valid? "foo.com" #=> true

--- a/lib/naughty_or_nice.rb
+++ b/lib/naughty_or_nice.rb
@@ -1,13 +1,8 @@
 require 'public_suffix'
 require "addressable/uri"
+require_relative './naughty_or_nice/version'
 
-class NaughtyOrNice
-
-  class << self
-    def valid?(text)
-      self.new(text).valid?
-    end
-  end
+module NaughtyOrNice
 
   # Source: http://bit.ly/1n2X9iv
   EMAIL_REGEX = %r{
@@ -47,6 +42,17 @@ class NaughtyOrNice
         )
         $
       }xi
+
+  module ClassMethods
+    def valid?(text)
+      self.new(text).valid?
+    end
+  end
+
+  # Ruby idiom that allows `include` to create class methods
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
 
   def initialize(domain)
     if domain.is_a?(PublicSuffix::Domain)

--- a/lib/naughty_or_nice/version.rb
+++ b/lib/naughty_or_nice/version.rb
@@ -1,0 +1,3 @@
+module NaughtyOrNice
+  VERSION = "1.0.0"
+end

--- a/naughty_or_nice.gemspec
+++ b/naughty_or_nice.gemspec
@@ -1,4 +1,4 @@
-require_relative './lib/naughty_or_nice/version'
+require File.expand_path("../lib/naughty_or_nice/version", __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name    = 'naughty_or_nice'

--- a/naughty_or_nice.gemspec
+++ b/naughty_or_nice.gemspec
@@ -1,6 +1,8 @@
+require_relative './lib/naughty_or_nice/version'
+
 Gem::Specification.new do |gem|
   gem.name    = 'naughty_or_nice'
-  gem.version = "0.0.4"
+  gem.version = NaughtyOrNice::VERSION
 
   gem.summary     = "You've made the list. We'll help you check it twice. Given a domain-like string, verifies inclusion in a list you provide."
   gem.description = "Naughty or Nice simplifies the process of extracting domain information from a domain-like string (an email, a URL, etc.) and checking whether it meets criteria you specify."

--- a/naughty_or_nice.gemspec
+++ b/naughty_or_nice.gemspec
@@ -20,5 +20,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('pry', '~> 0.9')
   gem.add_development_dependency('shoulda', '~> 3.5')
   gem.add_development_dependency('rake', '~> 10.3')
-
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -6,3 +6,7 @@ require 'shoulda'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 require 'naughty_or_nice'
+
+class TestHelper
+  include NaughtyOrNice
+end

--- a/test/test_naughty_or_nice.rb
+++ b/test/test_naughty_or_nice.rb
@@ -1,44 +1,44 @@
 require 'helper'
 
-class TestNaughtyOrNice < Minitest::Test
+class TestTestHelper < Minitest::Test
 
   should "properly parse domains from strings" do
-    assert_equal "github.gov", NaughtyOrNice.new("foo@github.gov").domain
-    assert_equal "foo.github.gov", NaughtyOrNice::new("foo.github.gov").domain
-    assert_equal "github.gov", NaughtyOrNice::new("http://github.gov").domain
-    assert_equal "github.gov", NaughtyOrNice::new("https://github.gov").domain
-    assert_equal ".gov", NaughtyOrNice::new(".gov").domain
-    assert_equal nil, NaughtyOrNice.new("foo").domain
+    assert_equal "github.gov", TestHelper.new("foo@github.gov").domain
+    assert_equal "foo.github.gov", TestHelper::new("foo.github.gov").domain
+    assert_equal "github.gov", TestHelper::new("http://github.gov").domain
+    assert_equal "github.gov", TestHelper::new("https://github.gov").domain
+    assert_equal ".gov", TestHelper::new(".gov").domain
+    assert_equal nil, TestHelper.new("foo").domain
   end
 
   should "accept PublicSuffix::Domains" do
     domain = PublicSuffix.parse("foo.gov")
-    assert_equal "foo.gov", NaughtyOrNice.new(domain).domain
+    assert_equal "foo.gov", TestHelper.new(domain).domain
   end
 
   should "not err out on invalid domains" do
-    assert_equal false, NaughtyOrNice.valid?("foo@gov.invalid")
-    assert_equal "gov.invalid", NaughtyOrNice.new("foo@gov.invalid").domain
-    assert_equal nil, NaughtyOrNice.new("foo@gov.invalid").domain_parts
+    assert_equal false, TestHelper.valid?("foo@gov.invalid")
+    assert_equal "gov.invalid", TestHelper.new("foo@gov.invalid").domain
+    assert_equal nil, TestHelper.new("foo@gov.invalid").domain_parts
   end
 
   should "return public suffix domain" do
-    assert_equal PublicSuffix::Domain, NaughtyOrNice.new("whitehouse.gov").domain_parts.class
-    assert_equal NilClass, NaughtyOrNice.new("foo.invalid").domain_parts.class
+    assert_equal PublicSuffix::Domain, TestHelper.new("whitehouse.gov").domain_parts.class
+    assert_equal NilClass, TestHelper.new("foo.invalid").domain_parts.class
   end
 
   should "parse domain parts" do
-    assert_equal "gov", NaughtyOrNice.new("foo@bar.gov").domain_parts.tld
-    assert_equal "bar", NaughtyOrNice.new("foo.bar.gov").domain_parts.sld
-    assert_equal "bar", NaughtyOrNice.new("https://foo.bar.gov").domain_parts.sld
-    assert_equal "bar.gov", NaughtyOrNice.new("foo@bar.gov").domain_parts.domain
+    assert_equal "gov", TestHelper.new("foo@bar.gov").domain_parts.tld
+    assert_equal "bar", TestHelper.new("foo.bar.gov").domain_parts.sld
+    assert_equal "bar", TestHelper.new("https://foo.bar.gov").domain_parts.sld
+    assert_equal "bar.gov", TestHelper.new("foo@bar.gov").domain_parts.domain
   end
 
   should "not err out on invalid hosts" do
-    assert_equal nil, NaughtyOrNice.new("</@foo.com").domain
+    assert_equal nil, TestHelper.new("</@foo.com").domain
   end
 
   should "not err out on invalid email addresses" do
-    assert_equal nil, NaughtyOrNice.new(":foo@bar.gov").domain
+    assert_equal nil, TestHelper.new(":foo@bar.gov").domain
   end
 end


### PR DESCRIPTION
Because Ruby.

Now the magic methods will be included via `include NaughtyOrNice`, rather than extending a parent class. This allows us to version the child gems programmatically.