### PR TITLE
NaughtyOrNice#Domain should return the PublicSuffix::Domain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ langauage: ruby
 rvm:
   - 2.1
 script: "script/cibuild"
+sudo: false
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 langauage: ruby
+rvm:
+  - 2.1
 script: "script/cibuild"

--- a/README.md
+++ b/README.md
@@ -21,12 +21,25 @@ class Checker
   DOMAINS = %w[foo.com bar.com foobar.com]
 
   def valid?
-    DOMAINS.include? domain
+    DOMAINS.include? domain.to_s
   end
 end
 ```
 
 That's it! Just overwrite the `valid?` method and Naughty or Nice takes care of the rest.
+
+You can also get more complicated. Let's say you only wanted to allow `.gov` domains:
+
+```ruby
+class Checker
+
+  include NaughtyOrNice
+
+  def valid?
+    domain.tld == ".gov"
+  end
+end
+```
 
 ## Using the included methods
 
@@ -54,9 +67,9 @@ You can also you NaughtyOrNice to extract domain information for use elsewhere. 
 ```ruby
 address = Checker.new "baz@foo.bar.com"
 address.valid?           #=> true
-address.domain           #=> "foo.bar.com"
-address.domain_parts.tld #=> "com"
-address.domain_parts.sld #=> "bar"
+address.domain.to_s      #=> "foo.bar.com"
+address.domain.tld       #=> "com"
+address.domain.sld       #=> "bar"
 ```
 
 ## See it in action

--- a/lib/naughty_or_nice/version.rb
+++ b/lib/naughty_or_nice/version.rb
@@ -1,3 +1,3 @@
 module NaughtyOrNice
-  VERSION = "1.0.0"
+  VERSION = "2.0.0"
 end

--- a/test/test_naughty_or_nice.rb
+++ b/test/test_naughty_or_nice.rb
@@ -1,37 +1,44 @@
 require 'helper'
 
 class TestTestHelper < Minitest::Test
-
   should "properly parse domains from strings" do
-    assert_equal "github.gov", TestHelper.new("foo@github.gov").domain
-    assert_equal "foo.github.gov", TestHelper::new("foo.github.gov").domain
-    assert_equal "github.gov", TestHelper::new("http://github.gov").domain
-    assert_equal "github.gov", TestHelper::new("https://github.gov").domain
-    assert_equal ".gov", TestHelper::new(".gov").domain
-    assert_equal nil, TestHelper.new("foo").domain
+    assert_equal "github.gov", TestHelper.new("foo@github.gov").send(:domain_text)
+    assert_equal "foo.github.gov", TestHelper::new("foo.github.gov").send(:domain_text)
+    assert_equal "github.gov", TestHelper::new("http://github.gov").send(:domain_text)
+    assert_equal "github.gov", TestHelper::new("https://github.gov").send(:domain_text)
+    assert_equal ".gov", TestHelper::new(".gov").send(:domain_text)
+    assert_equal nil, TestHelper.new("foo").send(:domain_text)
   end
 
   should "accept PublicSuffix::Domains" do
     domain = PublicSuffix.parse("foo.gov")
-    assert_equal "foo.gov", TestHelper.new(domain).domain
+    assert_equal "foo.gov", TestHelper.new(domain).domain.to_s
+  end
+
+  should "accept string domains" do
+    assert_equal "foo.gov", TestHelper.new("foo.gov").domain.to_s
+  end
+
+  should "return the domain string" do
+    assert_equal "foo.gov", TestHelper.new("foo.gov").to_s
   end
 
   should "not err out on invalid domains" do
     assert_equal false, TestHelper.valid?("foo@gov.invalid")
-    assert_equal "gov.invalid", TestHelper.new("foo@gov.invalid").domain
-    assert_equal nil, TestHelper.new("foo@gov.invalid").domain_parts
+    assert_equal nil, TestHelper.new("foo@gov.invalid").domain
+    assert_equal nil, TestHelper.new("foo@gov.invalid").to_s
   end
 
   should "return public suffix domain" do
-    assert_equal PublicSuffix::Domain, TestHelper.new("whitehouse.gov").domain_parts.class
-    assert_equal NilClass, TestHelper.new("foo.invalid").domain_parts.class
+    assert_equal PublicSuffix::Domain, TestHelper.new("whitehouse.gov").domain.class
+    assert_equal NilClass, TestHelper.new("foo.invalid").domain.class
   end
 
   should "parse domain parts" do
-    assert_equal "gov", TestHelper.new("foo@bar.gov").domain_parts.tld
-    assert_equal "bar", TestHelper.new("foo.bar.gov").domain_parts.sld
-    assert_equal "bar", TestHelper.new("https://foo.bar.gov").domain_parts.sld
-    assert_equal "bar.gov", TestHelper.new("foo@bar.gov").domain_parts.domain
+    assert_equal "gov", TestHelper.new("foo@bar.gov").domain.tld
+    assert_equal "bar", TestHelper.new("foo.bar.gov").domain.sld
+    assert_equal "bar", TestHelper.new("https://foo.bar.gov").domain.sld
+    assert_equal "bar.gov", TestHelper.new("foo@bar.gov").domain.domain
   end
 
   should "not err out on invalid hosts" do


### PR DESCRIPTION
This pull request changes the behavior of `NaughtyOrNice#Domain` to return the `PublicSuffix::Domain` object, rather than the string representing the domain.

To get the domain string you'll now want to use either the `to_s` method, or `domain.to_s`.

The idea here is that it makes more sense to pass around a Domain object, rather than re-parsing a string each time, which should give us a tiny performance improvement. 

It also means that when we do get the string representation, we're more consistent (by rebuilding the domain from its parts, rather than blindly returning the input string).